### PR TITLE
perf config: Improvement the check routine of mutual exclusivity using between system and user config

### DIFF
--- a/tools/perf/builtin-config.c
+++ b/tools/perf/builtin-config.c
@@ -28,8 +28,8 @@ enum actions {
 static struct option config_options[] = {
 	OPT_SET_UINT('l', "list", &actions,
 		     "show current config variables", ACTION_LIST),
-	OPT_BOOLEAN(0, "system", &use_system_config, "use system config file"),
-	OPT_BOOLEAN(0, "user", &use_user_config, "use user config file"),
+	OPT_BOOLEAN_FLAG(0, "system", &use_system_config, "use system config file", PARSE_OPT_EXCLUSIVE),
+	OPT_BOOLEAN_FLAG(0, "user", &use_user_config, "use user config file", PARSE_OPT_EXCLUSIVE),
 	OPT_END()
 };
 
@@ -60,13 +60,6 @@ int cmd_config(int argc, const char **argv, const char *prefix __maybe_unused)
 
 	argc = parse_options(argc, argv, config_options, config_usage,
 			     PARSE_OPT_STOP_AT_NON_OPTION);
-
-	if (use_system_config && use_user_config) {
-		pr_err("Error: only one config file at a time\n");
-		parse_options_usage(config_usage, config_options, "user", 0);
-		parse_options_usage(NULL, config_options, "system", 0);
-		return -1;
-	}
 
 	if (use_system_config)
 		config_exclusive_filename = perf_etc_perfconfig();


### PR DESCRIPTION
Change system and user config_options from OPT_BOOLEAN to OPT_BOOLEAN_FLAG
and add option 'PARSE_OPT_EXCLUSIVE' on it

So, There are no need to check mutual exclusivity using between system and user config.
