### PR TITLE
perf config: fix bug in parsing 'man.<tool>.*' config

### DIFF
--- a/tools/perf/util/config.c
+++ b/tools/perf/util/config.c
@@ -124,7 +124,7 @@ static char *parse_value(void)
 
 static inline int iskeychar(int c)
 {
-	return isalnum(c) || c == '-' || c == '_';
+	return isalnum(c) || c == '-' || c == '.' || c == '.';
 }
 
 static int get_value(config_fn_t fn, void *data, char *name, unsigned int len)


### PR DESCRIPTION
To add new man viewer, configs like 'man.<tool>.cmd',
'man.<tool>.path' can be set into config file (~/.perfconfig).
But parsing config file is stopped because the config variable
contains '.' character i.e.

If setting 'man.xman.cmd' into config file,

```
    [man]
        gman.cmd = gman
```

when launching perf an error message is printed like below.

```
    Fatal: bad config file line 11 in /home/taeung/.perfconfig
```

So modify iskeychar() function to decide '.' character
as key character parsing config file.

Acked-by: Namhyung Kim namhyung@kernel.org
Cc: Jiri Olsa jolsa@kernel.org
Signed-off-by: Kim SeonYoung adamas0414@naver.com
