### PR TITLE
perf report: Add more tips to 21th tips

### DIFF
--- a/tools/perf/Documentation/tips.txt
+++ b/tools/perf/Documentation/tips.txt
@@ -19,6 +19,7 @@ Treat branches as callchains: perf report --branch-history
 To count events in every 1000 msec: perf stat -I 1000
 Print event counts in CSV format with: perf stat -x,
 If you have debuginfo enabled, try: perf report -s sym,srcline
+Show source files and numbers in sequence of overhead, try :perf report -s srcline
 For memory address profiling, try: perf mem record / perf mem report
 For tracepoint events, try: perf report -s trace_fields
 To record callchains for each sample: perf record -g


### PR DESCRIPTION
'perf report -s srcline' command show source files and number in sequence of from top overhead to bottom.

If we want to know what the hottest source file is or the order of source files and numbers with overhead, we can use this command.

Signed-off-by: Kim SeonYoung adamas0414@gmail.com
Cc: Namhyung Kim namhyung@kernel.org
Cc: Jiri Olsa jolsa@kernel.org
Cc: Taeung Song taeung@kosslab.kr
