### PR TITLE
perf config: Fix a bug about permission checking state of config file

### DIFF
--- a/tools/perf/util/config.c
+++ b/tools/perf/util/config.c
@@ -619,6 +619,7 @@ static int perf_config_set__init(struct perf_config_set *set)
 	if (perf_config_global() && home) {
 		char *user_config = strdup(mkpath("%s/.perfconfig", home));
 		struct stat st;
+		unsigned int st_euid = geteuid();
 
 		if (user_config == NULL) {
 			warning("Not enough memory to process %s/.perfconfig, "
@@ -629,7 +630,7 @@ static int perf_config_set__init(struct perf_config_set *set)
 		if (stat(user_config, &st) < 0)
 			goto out_free;
 
-		if (st.st_uid && (st.st_uid != geteuid())) {
+		if (st.st_uid && st_euid && (st.st_uid != st_euid)) {
 			warning("File %s not owned by current user or root, "
 				"ignoring it.", user_config);
 			goto out_free;


### PR DESCRIPTION
perf_config_set__init() check state of user config file
before opening it. But there is a bug when checking uid
and euid of current user. Although current user have superuser
permission, a error occurs as below.

Before:

user01@localhost:~$ ls -l ~/.perfconfig
-rw-rw-r-- 1 user01 user01 89 2016-09-30 01:52 /home/user01/.perfconfig

user01@localhost:~/linux-perf/tools/perf/util$ sudo perf config --list
  Warning: File /home/user01/.perfconfig not owned by current user or root, ignoring it.
  Warning: File /home/user01/.perfconfig not owned by current user or root, ignoring it.

So, Fix it allowing a user who have superuser permission
to open user config file.

After:

user01@localhost:~$ ls -l ~/.perfconfig
-rw-rw-r-- 1 user01 user01 89  2016-09-30 01:52 /home/user01/.perfconfig

user01@localhost:~$ sudo perf config --list
annotate.hide_src_code=false
report.queue-size=0
tui.report=on
colors.top=red, default

Cc: Taeung Song taeung@kosslab.kr
Cc: Namhyung Kim namhyung@kernel.org
Cc: Jiri Olsa jolsa@kernel.org
Signed-off-by: Wookje Kwon aweee0@gmail.com
