### PR TITLE
perf report: Add a tip about  source line numbers with overhead

### DIFF
--- a/tools/perf/Documentation/tips.txt
+++ b/tools/perf/Documentation/tips.txt
@@ -28,3 +28,4 @@ To change sampling frequency to 100 Hz: perf record -F 100
 See assembly instructions with percentage: perf annotate <symbol>
 If you prefer Intel style assembly, try: perf annotate -M intel
 For hierarchical output, try: perf report --hierarchy
+Show source files and line numbers in sequence of overhead, try: perf report -s srcline


### PR DESCRIPTION
There is a existing tip as below.

```
If you have debuginfo enabled, try: perf report -s sym,srcline
```

However this tip only describe a condition to use --sort sym,scrline options.
So there is lack of explanation in the tip. I think that it would be better to
add a tip that exactly explain the feature of --sort srcline.

Signed-off-by: Kim SeonYoung adamas0414@gmail.com
Cc: Namhyung Kim namhyung@kernel.org
Cc: Jiri Olsa jolsa@kernel.org
Cc: Taeung Song taeung@kosslab.kr
