### PR TITLE
perf config: Add tips about a list option

### DIFF
--- a/tools/perf/Documentation/tips.txt
+++ b/tools/perf/Documentation/tips.txt
@@ -28,3 +28,5 @@ To change sampling frequency to 100 Hz: perf record -F 100
 See assembly instructions with percentage: perf annotate <symbol>
 If you prefer Intel style assembly, try: perf annotate -M intel
 For hierarchical output, try: perf report --hierarchy
+Show current config key-value pairs: perf config --list
+Show user configuration overrides: perf config --user --list


### PR DESCRIPTION
Add two tips that describe --list option of config sub-command
and explain how to choose particular config file location.

Signed-off-by: Nambong Ha over3025@gmail.com
Cc: Namhyung Kim namhyung@kernel.org
Cc: Jiri Olsa jolsa@kernel.org
Cc: Taeung Song taeung@kosslab.kr
